### PR TITLE
Add Docker Image CI badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Combinations App
 
 [![Backend Tests](https://github.com/Thomas-Griffin/Impossible-Creatures-Combinations-Web-App/actions/workflows/backend-tests.yml/badge.svg)](https://github.com/Thomas-Griffin/Impossible-Creatures-Combinations-Web-App/actions/workflows/backend-tests.yml)
 [![CodeQL](https://github.com/Thomas-Griffin/Impossible-Creatures-Combinations-Web-App/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/Thomas-Griffin/Impossible-Creatures-Combinations-Web-App/actions/workflows/github-code-scanning/codeql)
+[![Docker Image CI](https://github.com/Thomas-Griffin/Impossible-Creatures-Combinations/actions/workflows/docker-image.yml/badge.svg)](https://github.com/Thomas-Griffin/Impossible-Creatures-Combinations/actions/workflows/docker-image.yml)
 
 Getting Started
 ---------------


### PR DESCRIPTION
The Docker Image Continuous Integration (CI) status badge has been added to the README file. This allows users and contributors to easily see the status of the latest Docker image build.